### PR TITLE
Allow interaction with both sides of the StepperTouch

### DIFF
--- a/app/src/main/java/nl/dionsegijn/steppertouchdemo/MainActivity.kt
+++ b/app/src/main/java/nl/dionsegijn/steppertouchdemo/MainActivity.kt
@@ -22,9 +22,10 @@ class MainActivity : AppCompatActivity() {
             }
         })
 
-        val stepperTouchBlue = findViewById(R.id.stepperTouch2) as StepperTouch
-        stepperTouchBlue.stepper.setMin(-10)
-        stepperTouchBlue.stepper.setMax(10)
+        val bottemStepperTouch = findViewById(R.id.bottomStepperTouch) as StepperTouch
+        bottemStepperTouch.stepper.setMin(-10)
+        bottemStepperTouch.stepper.setMax(10)
+        bottemStepperTouch.enableSideTap(true)
     }
 
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -33,7 +33,7 @@
         android:gravity="center">
 
         <nl.dionsegijn.steppertouch.StepperTouch
-            android:id="@+id/stepperTouch2"
+            android:id="@+id/bottomStepperTouch"
             android:layout_width="130dp"
             android:layout_height="50dp"
             android:layout_margin="40dp"

--- a/library/src/main/java/nl/dionsegijn/steppertouch/StepperCounter.kt
+++ b/library/src/main/java/nl/dionsegijn/steppertouch/StepperCounter.kt
@@ -21,7 +21,7 @@ internal class StepperCounter : LinearLayout, Stepper {
         }
 
     var count: Int by Delegates.observable(0, {
-        prop, old, new -> updateView(new); notifyStepCallback(new, new > old)
+        _, old, new -> updateView(new); notifyStepCallback(new, new > old)
     })
 
     var maxValue: Int = Integer.MAX_VALUE


### PR DESCRIPTION
Implementation to allow interaction with both sides of the StepperTouch (fixes #4)

To enable this behavior call the following:

```Kotlin
stepperTouch.enableSideTap(true)
```
Suggestions for better naming is welcome 🙈

The current implementation makes use of the already existing `onTouchEvent` in StepperTouch. It will alter its behavior based on the click and if side tap is enabled.

- [ ] Look at the function names, can be improved. 