### PR TITLE
Fix size stepper counter

### DIFF
--- a/library/src/main/java/nl/dionsegijn/steppertouch/StepperTouch.kt
+++ b/library/src/main/java/nl/dionsegijn/steppertouch/StepperTouch.kt
@@ -13,7 +13,6 @@ import android.util.AttributeSet
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.MotionEvent
-import android.view.ViewTreeObserver
 import android.widget.FrameLayout
 import android.widget.TextView
 
@@ -72,14 +71,6 @@ class StepperTouch : FrameLayout, OnStepCallback {
 
     init {
         clipChildren = true
-        viewTreeObserver.addOnPreDrawListener(object : ViewTreeObserver.OnPreDrawListener {
-            override fun onPreDraw(): Boolean {
-                viewTreeObserver.removeOnPreDrawListener(this)
-                newHeight = height
-                setStepperSize(viewStepper)
-                return true
-            }
-        })
     }
 
     private fun prepareElements() {
@@ -189,4 +180,11 @@ class StepperTouch : FrameLayout, OnStepCallback {
     private fun pxFromDp(dp: Float): Float {
         return dp * resources.displayMetrics.density
     }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        newHeight = measuredHeight
+        setStepperSize(viewStepper)
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+    }
+
 }


### PR DESCRIPTION
When initializing Stepper counter in a view which was minimized (i.e. see #5) and afterwards expanded, Stepper Touch didn't take the new size into account.

This fix lets Stepper Touch listen to the `onMeasure` and update its size when requested by the system.