### PR TITLE
Added a quick example for Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ stepperTouch.stepper.addStepCallback(object : OnStepCallback {
 })
 ```
 
+Quick example written in Java:
+
+```Java
+StepperTouch stepperTouch = (StepperTouch) findViewById(R.id.stepperTouch);
+        stepperTouch.stepper.setMin(0);
+        stepperTouch.stepper.setMax(3);
+        stepperTouch.stepper.addStepCallback(new OnStepCallback() {
+            @Override
+            public void onStep(int value, boolean positive) {
+                Toast.makeText(getApplicationContext(), value + "", Toast.LENGTH_SHORT).show();
+            }
+        });
+```
+
 You are able to further customize or set initial values with styled attributes: 
 
 Add res-auto to your xml layout if you haven't yet

--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ Quick example written in Java:
 
 ```Java
 StepperTouch stepperTouch = (StepperTouch) findViewById(R.id.stepperTouch);
-        stepperTouch.stepper.setMin(0);
-        stepperTouch.stepper.setMax(3);
-        stepperTouch.stepper.addStepCallback(new OnStepCallback() {
-            @Override
-            public void onStep(int value, boolean positive) {
-                Toast.makeText(getApplicationContext(), value + "", Toast.LENGTH_SHORT).show();
-            }
-        });
+stepperTouch.stepper.setMin(0);
+stepperTouch.stepper.setMax(3);
+stepperTouch.stepper.addStepCallback(new OnStepCallback() {
+    @Override
+    public void onStep(int value, boolean positive) {
+        Toast.makeText(getApplicationContext(), value + "", Toast.LENGTH_SHORT).show();
+    }
+});
 ```
 
 You are able to further customize or set initial values with styled attributes: 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ dependencies {
         android:layout_height="40dp" />
 ```
 
-Quick example written in Kotlin:
+### Kotlin
 
 ```Kotlin
 val stepperTouch = findViewById(R.id.stepperTouch) as StepperTouch
@@ -57,7 +57,7 @@ stepperTouch.stepper.addStepCallback(object : OnStepCallback {
 })
 ```
 
-Quick example written in Java:
+### Java
 
 ```Java
 StepperTouch stepperTouch = (StepperTouch) findViewById(R.id.stepperTouch);


### PR DESCRIPTION
I looked over the readme file of this library because I wanted to implement this in some of my apps. I saw an example for Kotlin, but not Java! So I quickly typed up the quick example into Java. I also want other users that come up to your library to be able to easily use this component in Java by viewing the Java example.